### PR TITLE
Add support for AMD modules

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["airbnb"]
+  "presets": ["airbnb"],
+  "plugins": ["transform-es2015-modules-umd"]
 }

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
+    "babel-plugin-transform-es2015-modules-umd": "^6.24.1",
     "babel-preset-airbnb": "^2.5.3",
     "chai": "^4.1.2",
     "enzyme": "^3.4.1",


### PR DESCRIPTION
This PR just adds a babel plugin to transform the library into an es2015 UMD module. That way the plugin can be used in async js loaders libraries like require.js.
More information about the plugin:
https://babeljs.io/docs/en/babel-plugin-transform-es2015-modules-umd

Usage:
`<!DOCTYPE html>
<html>
    <head>
        <title>My Sample Project</title>
        <!-- data-main attribute tells require.js to load
             scripts/main.js after require.js loads. -->
        <script src="https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js"></script>
    </head>
    <body>
        <h1>My Sample Project</h1>
    </body>

    <script>
      require.config({
        paths: {
          'react': 'https://unpkg.com/react@16/umd/react.production.min',
          'react-dom': 'https://unpkg.com/react-dom@16/umd/react-dom.production.min',
          'react-dom/server': 'https://unpkg.com/react-dom@16/umd/react-dom-server.browser.production.min',
          'hypernova': 'https://cdn.jsdelivr.net/npm/hypernova@2.5.0/lib/index.min',
          'hypernova-react': 'https://cdn.jsdelivr.net/npm/hypernova-react@2.1.0/lib/index.min',
        },
        waitSeconds: 15
      });

      require(['react', 'react-dom', 'react-dom/server', 'hypernova', 'hypernova-react'],
        function(React, ReactDOM, ReactDOMServer, hypernova, hypernovaReact){
          console.log('react -> ', React);
          console.log('react-dom -> ', ReactDOM);
          console.log('react-dom-server ->', ReactDOMServer);
          console.log('hypernova -> ', hypernova);
          console.log('hypernova-react -> ', hypernovaReact);

          /* client-side script */
      });
    </script>
</html>
`